### PR TITLE
Add BitAttr class to ease defining bit attributes in Struct

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,5 @@ Style/FormatString:
   EnforcedStyle: percent
 Style/FormatStringToken:
   MaxUnannotatedPlaceholdersAllowed: 3
+Style/HashLikeCase:
+  MinBranchesCount: 4

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ gemspec
 group :develoment do
   gem 'rake', '~> 13.0'
   gem 'rspec', '~> 3.12'
-  gem 'solargraph'
+  gem 'ruby-lsp'
+  gem 'yard', '~>0.9'
 end
 
 group :rubocop do

--- a/lib/bin_struct.rb
+++ b/lib/bin_struct.rb
@@ -25,6 +25,7 @@ end
 require_relative 'bin_struct/structable'
 require_relative 'bin_struct/int'
 require_relative 'bin_struct/enum'
+require_relative 'bin_struct/bit_attr'
 require_relative 'bin_struct/struct'
 require_relative 'bin_struct/length_from'
 require_relative 'bin_struct/abstract_tlv'

--- a/lib/bin_struct/bit_attr.rb
+++ b/lib/bin_struct/bit_attr.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+# This file is part of BinStruct
+# see https://github.com/lemontree55/bin_struct for more informations
+# Copyright (C) 2024 LemonTree55 <lenontree@proton.me>
+# This program is published under MIT license.
+require 'digest'
+
+module BinStruct
+  # Define a bitfield attribute to embed in a {Struct}.
+  #
+  #  class MyStruct < BinStruct::Struct
+  #    # Create a 32-bit bitfield attribute, with fields a (16 bits), b and c (4 bits each) and d (8 bits).
+  #    # a is the leftmost field in bitfield, and d the rightmost one.
+  #    define_attr :int32, BinStruct::BitAttr.create(width: 32, a: 16, b: 4, c: 4, d:8)
+  #  end
+  # @since 0.3.0
+  # @author LemonTree55
+  class BitAttr
+    include Structable
+
+    # @return [Integer] width in bits of bit attribute
+    attr_reader :width
+    # @return [Array[Symbol]]
+    attr_reader :bit_methods
+
+    # @private
+    Parameters = Struct.new(:width, :fields, :int)
+
+    class << self
+      @cache = {}
+
+      # @private
+      # @return [Parameters]
+      attr_reader :parameters
+
+      # Create a new {BitAttr} subclass with specified parameters
+      # @param [Integer] width size of bitfields in bits. Must be a size of an {Int} (8, 16, 24, 32 or 64 bits).
+      # @param [:big,:little,:native] endian endianess of bit attribute as an integer
+      # @param [Hash{Symbol=>Integer}] fields hash associating field names with their size. Total size MUST be equal
+      #    to +width+.
+      # @return [Class]
+      # @raise [ArgumentError] raise if:
+      #    * width is not a size of one of {Int} subclasses,
+      #    * sum of bitfield sizes is not equal to +width+
+      def create(width:, endian: :big, **fields)
+        raise ArgumentError, 'with must be 8, 16, 24, 32 or 64' unless [8, 16, 24, 32, 64].include?(width)
+
+        hsh = compute_hash(width, endian, fields)
+        cached = cache[hsh]
+        return cached if cached
+
+        total_size = fields.reduce(0) { |acc, ary| acc + ary.last }
+        raise ArgumentError, "sum of bitfield sizes is not equal to #{width}" unless total_size == width
+
+        cache[hsh] = Class.new(self) do
+          int_klass = BinStruct.const_get("Int#{width}")
+          @parameters = Parameters.new(width, fields, int_klass.new(endian: endian)).freeze
+        end
+      end
+
+      private
+
+      # @return [Hash{::String=>Class}]
+      def cache
+        return @cache if defined? @cache
+
+        @cache = {}
+      end
+
+      # @param [::Array] params
+      # @return [::String]
+      def compute_hash(*params)
+        Digest::MD5.digest(Marshal.dump(params))
+      end
+    end
+
+    # Initialize bit attribute
+    # @param [Hash{Symbol=>Integer}] opts initialization values for fields, where keys are field names and values are
+    #     initialization values
+    # @return [self]
+    def initialize(opts = {})
+      parameters = self.class.parameters
+      raise NotImplementedError, '#initialize may only be called on subclass of {self.class}' if parameters.nil?
+
+      @width = parameters.width
+      @fields = parameters.fields
+      @int = parameters.int.dup
+      @data = {}
+      @bit_methods = []
+
+      parameters.fields.each do |name, size|
+        @data[name] = opts[name] || 0
+        define_methods(name, size)
+      end
+      @bit_methods.freeze
+    end
+
+    # Populate bit attribute from +str+
+    # @param [::String,nil] str
+    # @return [self]
+    def read(str)
+      return self if str.nil?
+
+      @int.read(str)
+      compute_data(@int.to_i)
+    end
+
+    # Give integer associated to this attribute
+    # @return [Integer]
+    def to_i
+      v = 0
+      @fields.each do |name, size|
+        v <<= size
+        v |= @data[name]
+      end
+
+      v
+    end
+    alias to_human to_i
+
+    # Return binary string
+    # @return [::String]
+    def to_s
+      @int.value = to_i
+      @int.to_s
+    end
+
+    # Set fields from associated integer
+    # @param [#to_i] value
+    # @return [self]
+    def from_human(value)
+      compute_data(value.to_i)
+    end
+
+    private
+
+    # @param [Integer] value
+    # @return [self]
+    def compute_data(value)
+      @fields.reverse_each do |name, size|
+        @data[name] = value & ((2**size) - 1)
+        value >>= size
+      end
+
+      self
+    end
+
+    # @param [Symbol] name
+    # @return [void]
+    def define_methods(name, size)
+      instance_eval "def #{name}; @data[#{name.inspect}]; end\n", __FILE__, __LINE__ # def name; data[:name]; end
+      bit_methods << name
+      bit_methods << :"#{name}="
+
+      # rubocop:disable Style/DocumentDynamicEvalDefinition
+      if size == 1
+        instance_eval "def #{name}?; @data[#{name.inspect}] != 0; end\n", __FILE__, __LINE__
+        instance_eval "def #{name}=(val); v = case val when TrueClass; 1 when FalseClass; 0 else val end; " \
+                      "@data[#{name.inspect}] = v; end", __FILE__, __LINE__ - 2
+        bit_methods << :"#{name}?"
+      else
+        instance_eval "def #{name}=(val); @data[#{name.inspect}] = val; end", __FILE__, __LINE__
+      end
+      # rubocop:enable Style/DocumentDynamicEvalDefinition
+    end
+  end
+end

--- a/lib/bin_struct/bit_attr.rb
+++ b/lib/bin_struct/bit_attr.rb
@@ -96,6 +96,19 @@ module BinStruct
       @bit_methods.freeze
     end
 
+    # Get type name
+    # @return [::String]
+    def type_name
+      return @type_name if defined? @type_name
+
+      endian_suffix = case @int.endian
+                      when :big then ''
+                      when :little then 'le'
+                      when :native then 'n'
+                      end
+      @type_name = "BitAttr#{@width}#{endian_suffix}"
+    end
+
     # Populate bit attribute from +str+
     # @param [::String,nil] str
     # @return [self]
@@ -131,6 +144,11 @@ module BinStruct
     # @return [self]
     def from_human(value)
       compute_data(value.to_i)
+    end
+
+    def format_inspect
+      str = @int.format_inspect << "\n"
+      str << @data.map { |name, value| "#{name}:#{value}" }.join(' ')
     end
 
     private

--- a/lib/bin_struct/int_string.rb
+++ b/lib/bin_struct/int_string.rb
@@ -61,7 +61,7 @@ module BinStruct
     # @return [::String]
     def string=(str)
       @length.value = str.to_s.size
-      @string = str.to_s
+      @string.read(str)
     end
 
     # Get binary string
@@ -82,7 +82,7 @@ module BinStruct
     # Get human readable string
     # @return [::String]
     def to_human
-      @string
+      @string.to_s
     end
 
     # Set length from internal string length

--- a/lib/bin_struct/struct.rb
+++ b/lib/bin_struct/struct.rb
@@ -260,13 +260,14 @@ module BinStruct
       # @param [Symbol] attr attribute name
       #   subclass)
       # @param [:big,:little,:native] endian endianess of Integer
+      # @param [Integer] default default value for whole attribute
       # @param [Hash{Symbol=>Integer}] fields Hash defining fields. Keys are field names, values are field sizes.
       # @return [void]
       # @since 0.3.0
-      def define_bit_attr(attr, endian: :big, **fields)
+      def define_bit_attr(attr, endian: :big, default: 0, **fields)
         width = fields.reduce(0) { |acc, ary| acc + ary.last }
         bit_attr_klass = BitAttr.create(width: width, endian: endian, **fields)
-        define_attr(attr, bit_attr_klass)
+        define_attr(attr, bit_attr_klass, default: default)
         fields.each_key { |field| register_bit_attr_field(attr, field) }
         bit_attr_klass.new.bit_methods.each do |meth|
           if meth.to_s.end_with?('=')

--- a/lib/bin_struct/struct.rb
+++ b/lib/bin_struct/struct.rb
@@ -88,15 +88,16 @@ module BinStruct
   # * +#frag+ and +#frag=+ to access +frag+ attribute as a 16-bit integer,
   # * +#flag_rsv?+, +#flag_rsv=+, +#flag_df?+, +#flag_df=+, +#flag_mf?+ and +#flag_mf=+
   #   to access Boolean RSV, MF and DF flags from +frag+ attribute,
+  # * +#flag_rsv+, +#flag_df+ and +#flag_mf# to read RSV, MF and DF flags as Integer,
   # * +#fragment_offset+ and +#fragment_offset=+ to access 13-bit integer fragment
   #   offset subattribute from +frag+ attribute.
   #
   # == Creating a new Struct class from another one
   # Some methods may help in this case:
-  # * {.define_attr_before} to define a new attribute before an existing one,
-  # * {.define_attr_after} to define a new attribute after an existing onr,
+  # * {.define_attr_before} and {.define_bit_attr_before} to define a new attribute before an existing one,
+  # * {.define_attr_after} and {.define_bit_attr_after} to define a new attribute after an existing onr,
   # * {.remove_attr} to remove an existing attribute,
-  # * {.uptade_fied} to change options of an attribute (but not its type),
+  # * {.uptade_attr} to change options of an attribute (but not its type),
   #
   # @author Sylvain Daubert (2016-2024)
   # @author LemonTree55
@@ -242,10 +243,9 @@ module BinStruct
         attr_defs[name].options.merge!(options)
       end
 
-      # Define a bit attribute on given attribute
+      # Define a bit attribute
       #   class MyHeader < BinStruct::Struct
-      #     define_attr :flags, BinStruct::Int16
-      #     # define a bit attribute named :flag
+      #     # define a 16-bit attribute named :flag
       #     # flag1, flag2 and flag3 are 1-bit attributes
       #     # type and stype are 3-bit attributes. reserved is a 7-bit attribute
       #     define_bit_attr :flags, flag1: 1, flag2: 1, flag3: 1, type: 3, stype: 3, reserved: 7
@@ -258,7 +258,6 @@ module BinStruct
       # * +#attr+ which returns an Integer,
       # * +#attr=+ which takes an Integer.
       # @param [Symbol] attr attribute name
-      #   subclass)
       # @param [:big,:little,:native] endian endianess of Integer
       # @param [Integer] default default value for whole attribute
       # @param [Hash{Symbol=>Integer}] fields Hash defining fields. Keys are field names, values are field sizes.

--- a/lib/bin_struct/struct.rb
+++ b/lib/bin_struct/struct.rb
@@ -270,6 +270,7 @@ module BinStruct
       # @param [:big,:little,:native] endian endianess of Integer
       # @param [Hash{Symbol=>Integer}] fields Hash defining fields. Keys are field names, values are field sizes.
       # @return [void]
+      # @since 0.3.0
       def define_bit_attr(attr, endian: :big, **fields)
         width = fields.reduce(0) { |acc, ary| acc + ary.last }
         bit_attr_klass = BitAttr.create(width: width, endian: endian, **fields)
@@ -577,26 +578,39 @@ module BinStruct
       end
     end
 
+    # @param [Symbol] attr
+    # @return [void]
     def initialize_optional(attr)
       optional = attr_defs[attr].optional
       @optional_attributes[attr] = optional if optional
     end
 
+    # @return [String]
     def inspect_titleize
       title = self.class.to_s
       +"-- #{title} #{'-' * (66 - title.length)}\n"
     end
 
+    # @param [:Symbol] attr
+    # @param [Structable] value
+    # @param [Integer] level
+    # @return [::String]
     def inspect_attribute(attr, value, level = 1)
-      type = value.class.to_s.sub(/.*::/, '')
-      inspect_format(type, attr, value.format_inspect, level)
-    end
-
-    def inspect_format(type, attr, value, level = 1)
       str = inspect_shift_level(level)
-      str << (FMT_ATTR % [type, attr, value])
+      value_lines = value.format_inspect.split("\n")
+      str << (FMT_ATTR % [value.type_name, attr, value_lines.shift])
+      return str if value_lines.empty?
+
+      shift = (FMT_ATTR % ['', '', 'START']).index('START')
+      value_lines.each do |l|
+        str << inspect_shift_level(level)
+        str << (' ' * shift) << l << "\n"
+      end
+      str
     end
 
+    # @param [Integer] level
+    # @return [String]
     def inspect_shift_level(level = 1)
       '  ' * (level + 1)
     end

--- a/lib/bin_struct/structable.rb
+++ b/lib/bin_struct/structable.rb
@@ -58,7 +58,7 @@ module BinStruct
     # Format object when inspecting a {Struct} object
     # @return [::String]
     def format_inspect
-      to_human
+      to_human.to_s
     end
   end
 end

--- a/spec/bit_attr_spec.rb
+++ b/spec/bit_attr_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+module BinStruct
+  RSpec.describe BitAttr do
+    describe '.create' do
+      it 'creates a new BitAttr subclass' do
+        ba = BitAttr.create(width:8, l: 4, r: 4)
+        expect(ba).to be_a(Class)
+        expect(ba).to be < BitAttr
+      end
+
+      it 'returns the same subclass from same parameters' do
+        ba1 = BitAttr.create(width: 8, l:4, r:4)
+        ba2 = BitAttr.create(width: 8, l:4, r:4)
+        expect(ba1.object_id).to eq(ba2.object_id)
+      end
+
+      it 'defines one getter method per field' do
+        ba = BitAttr.create(width: 8, l: 7, r: 1).new
+        expect(ba.methods).to include(:l, :r)
+      end
+
+      it 'defines one setter method per field' do
+        ba = BitAttr.create(width: 8, l: 7, r: 1).new
+        expect(ba.methods).to include(:l=, :r=)
+      end
+
+      it 'defines one query method per 1-bit field' do
+        ba = BitAttr.create(width: 8, l: 7, r: 1).new
+        expect(ba.methods).to include(:r?)
+        expect(ba.methods).to_not include(:l?)
+      end
+
+      it 'accepts a width of 8, 16, 24, 32 or 64' do
+        [8, 16, 24, 32, 64].each do |width|
+          expect { BitAttr.create(width: width, l: width/2, r: width/2) }.to_not raise_error
+        end
+      end
+
+      it 'raises for width not equal to 8, 16, 24, 32 or 64' do
+        [0, 1, 2, 7, 9, 15, 17, 23, 25, 31, 33, 63, 65, 1_000].each do |width|
+          expect { BitAttr.create(width: width, l: width/2, r: width/2) }.to raise_error(ArgumentError)
+        end
+      end
+
+      it 'raises if width is not equal to the sum of all field sizes' do
+        expect { BitAttr.create(width: 8, l: 4, r: 3) }.to raise_error(ArgumentError)
+        expect { BitAttr.create(width: 8, l: 4, r: 5) }.to raise_error(ArgumentError)
+      end
+    end
+
+    describe '#initialize' do
+      let(:ba_class) { BitAttr.create(width: 16, l: 8, r1:4, r2: 4) }
+
+      it 'accepts no parameters' do
+        ba = ba_class.new
+        expect(ba.l).to eq(0)
+        expect(ba.r1).to eq(0)
+        expect(ba.r2).to eq(0)
+      end
+
+      it 'accepts initial values for fields' do
+        ba = ba_class.new(l: 11, r1: 7, r2: 8)
+        expect(ba.l).to eq(11)
+        expect(ba.r1).to eq(7)
+        expect(ba.r2).to eq(8)
+      end
+
+      it 'accepts initial values from only a subsey of fields' do
+        ba = ba_class.new(l: 1_000, r2: 4)
+        expect(ba.l).to eq(1_000)
+        expect(ba.r1).to eq(0)
+        expect(ba.r2).to eq(4)
+      end
+    end
+
+    describe '#read' do
+      [[8, 0x1, 0xf], [16, 0x1f, 0x1f], [24, 0x1f1, 0xf1f], [32, 0x1f1f, 0x1f1f], [64, 0x1f1f1f1f, 0x1f1f1f1f]].each do |width, left, right|
+        it "reads a #{width}-bit attribute from a binary string" do
+          bin_str = ([0x1f] * (width / 8)).pack('C*')
+          ba = BitAttr.create(width: width, l: width/2, r: width/2).new
+          ba.read(bin_str)
+          expect(ba.l).to eq(left)
+          expect(ba.r).to eq(right)
+        end
+      end
+    end
+
+    describe '#to_i' do
+      it 'returns integer associated with fields' do
+        ba = BitAttr.create(width: 64, a: 8, b: 16, c: 32, d: 8).new(a: 1, b: 2, c: 3, d:4)
+        expect(ba.to_i).to eq(0x0100020000000304)
+
+        ba = BitAttr.create(width: 16, a: 8, b: 4, c: 4).new(a: 1, b: 2, c: 3)
+        expect(ba.to_i).to eq(0x0123)
+      end
+    end
+
+    describe '#to_s' do
+      [[8, 0x17, 'C'], [16, 0x1718, 'n'], [24, 0x171819, 'Cn'], [32, 0x1718191a, 'N'], [64, 0x1718191a1b1c1d1e, 'Q>']].each do |width, value, packstr|
+        it "generate a binary string from a #{width}-bit attribute" do
+          ba = BitAttr.create(width: width, l: width/2, r: width/2).new
+          ba.from_human(value)
+          bin_str = case width
+                    when 24
+                      [value >> 16, value & 0xffff]
+                    else
+                      [value]
+                    end.pack(packstr)
+          expect(ba.to_s).to eq(bin_str)
+        end
+      end
+    end
+
+    context 'with endian' do
+      [:big, :little, :native].each do |endian|
+        it "handles #{endian} endian attribute" do
+          ba_class = BitAttr.create(width: 32, endian: endian, l: 8, r: 24)
+          ba = ba_class.new(l: 0x33, r: 0xabcdef)
+          packstr = +"L"
+          packstr << ">" if endian == :big
+          packstr << "<" if endian == :little
+
+          expect(ba.to_i).to eq(0x33abcdef)
+          expect(ba.to_s).to eq([0x33abcdef].pack(packstr))
+        end
+      end
+    end
+  end
+end

--- a/spec/struct_spec.rb
+++ b/spec/struct_spec.rb
@@ -380,17 +380,9 @@ module BinStruct
       let(:inspect_lines) { BSStructSpec::FInspectTest.new.inspect.lines }
 
       it 'shows Int attributes' do
-        pending
         expect(inspect_lines).to include(/Int8\s+int: 0\s+\(0x00\)/)
-        expect(inspect_lines).to include(/Int16\s+int2: 0\s+\(0x0000\)/)
-      end
-
-      it 'does not show bit attributes' do
-        expect(inspect_lines).to_not include(/one/)
-        expect(inspect_lines).to_not include(/two/)
-        expect(inspect_lines).to_not include(/three/)
-        expect(inspect_lines).to_not include(/four/)
-        expect(inspect_lines).to_not include(/five/)
+        expect(inspect_lines).to include(/BitAttr16\s+int2: 0\s+\(0x0000\)/)
+        expect(inspect_lines).to include(/one:0 two:0 three:0 four:0 five:0/)
       end
 
       it 'shows Enum attributes' do

--- a/spec/struct_spec.rb
+++ b/spec/struct_spec.rb
@@ -285,6 +285,50 @@ module BinStruct
       end
     end
 
+    describe '.define_bit_attr_before' do
+      before(:each) do
+        BSStructSpec::STest.class_eval do
+          define_attr :f1, Int8
+          define_attr :f2, Int8
+        end
+      end
+
+      it 'adds a attribute before another one' do
+        BSStructSpec::STest.class_eval { define_bit_attr_before :f1, :f3, one: 1, two: 7 }
+        expect(BSStructSpec::STest.new.attributes).to eq(%i[f3 f1 f2])
+
+        BSStructSpec::STest.class_eval { define_bit_attr_before :f2, :f4, one: 8 }
+        expect(BSStructSpec::STest.new.attributes).to eq(%i[f3 f1 f4 f2])
+      end
+
+      it 'raises on unknown before attribute' do
+        expect { BSStructSpec::STest.class_eval { define_bit_attr_before :unk, :f3, one: 8 } }
+          .to raise_error(ArgumentError, 'unknown unk attribute')
+      end
+    end
+
+    describe '.define_bit_attr_after' do
+      before(:each) do
+        BSStructSpec::STest.class_eval do
+          define_attr :f1, Int8
+          define_attr :f2, Int8
+        end
+      end
+
+      it 'adds a attribute after another one' do
+        BSStructSpec::STest.class_eval { define_bit_attr_after :f1, :f3, one: 1, two: 7 }
+        expect(BSStructSpec::STest.new.attributes).to eq(%i[f1 f3 f2])
+
+        BSStructSpec::STest.class_eval { define_bit_attr_after :f2, :f4, one: 8 }
+        expect(BSStructSpec::STest.new.attributes).to eq(%i[f1 f3 f2 f4])
+      end
+
+      it 'raises on unknown after attribute' do
+        expect { BSStructSpec::STest.class_eval { define_bit_attr_before :unk, :f3, one: 8 } }
+          .to raise_error(ArgumentError, 'unknown unk attribute')
+      end
+    end
+
     describe '#initialize' do
       it 'accepts a Structurable object as value for an attribute' do
         object_value = Int8.new(value: 42)

--- a/spec/struct_spec.rb
+++ b/spec/struct_spec.rb
@@ -235,6 +235,16 @@ module BinStruct
         expect(ft.b2).to be(0)
       end
 
+      it 'adds a bit attribute with default value' do
+        BSStructSpec::STest.class_eval do
+          define_bit_attr :u8, default: 0x78, a: 4, b: 4
+        end
+        ft = BSStructSpec::STest.new
+        expect(ft.u8).to eq(0x78)
+        expect(ft.a).to eq(7)
+        expect(ft.b).to eq(8)
+      end
+
       it 'defines boolean methods on 1-bit attributes' do
         BSStructSpec::STest.class_eval do
           define_bit_attr :u8, b0: 1, b1: 1, b2: 6

--- a/spec/struct_spec.rb
+++ b/spec/struct_spec.rb
@@ -18,18 +18,15 @@ module BSStructSpec
   end
 
   class SOptional < BinStruct::Struct
-    define_attr :u8, BinStruct::Int32
-    define_bit_attrs_on :u8, :has_optional, :others, 31
+    define_bit_attr :u32, has_optional: 1, others: 31
     define_attr :optional, BinStruct::Int32, optional: lambda(&:has_optional?)
   end
 
   class FInspectTest < BinStruct::Struct
     define_attr :is, BinStruct::IntString, default: 'test'
     define_attr :int, BinStruct::Int8
-    define_attr :int2, BinStruct::Int16
+    define_bit_attr :int2, one: 4, two: 2, three: 1, four: 1, five: 8
     define_attr :enum, BinStruct::Int32Enum, enum: {'no' => 0, 'yes' => 1 }
-
-    define_bit_attrs_on :int2, :one, 4, :two, 2, :three, :four, :five, 8
   end
 
   class DeleteTest < BinStruct::Struct
@@ -201,16 +198,29 @@ module BinStruct
         expect(d2).to_not respond_to(:to_be_deleted )
         expect(d2).to_not respond_to(:to_be_deleted=)
       end
+
+      it 'removes defined bit attributes' do
+        BSStructSpec::STest.class_eval do
+          define_bit_attr :u8, b0: 1, b1: 1, b2: 1, b3: 1, b4: 1, b5: 1, b6: 1, b7: 1
+        end
+        ft = BSStructSpec::STest.new
+        expect(ft).to respond_to(:b0?)
+        expect(ft).to respond_to(:b0=)
+        expect(ft).to respond_to(:b7?)
+        expect(ft).to respond_to(:b7=)
+
+        BSStructSpec::STest.class_eval { remove_attr :u8 }
+        expect(ft).to_not respond_to(:b0?)
+        expect(ft).to_not respond_to(:b0=)
+        expect(ft).to_not respond_to(:b7?)
+        expect(ft).to_not respond_to(:b7=)
+      end
     end
 
-    describe '.define_bit_attrs_on' do
-      before(:each) do
-        BSStructSpec::STest.class_eval { define_attr :u8, Int8 }
-      end
-
-      it 'adds bit attributes on an Int attribute' do
+    describe '.define_bit_attr' do
+      it 'adds a bit attribute' do
         BSStructSpec::STest.class_eval do
-          define_bit_attrs_on :u8, :b0, :b1, :b2, :b3, :b4, :b5, :b6, :b7
+          define_bit_attr :u8, b0: 1, b1: 1, b2: 1, b3: 1, b4: 1, b5: 1, b6: 1, b7: 1
         end
         ft = BSStructSpec::STest.new
         8.times do |i|
@@ -220,72 +230,58 @@ module BinStruct
 
         expect(ft.u8).to eq(0)
         ft.u8 = 0x40
-        expect(ft.b0?).to be(false)
-        expect(ft.b1?).to be(true)
-        expect(ft.b2?).to be(false)
-
-        ft.b7 = true
-        ft.b1 = false
-        expect(ft.u8).to eq(1)
+        expect(ft.b0).to be(0)
+        expect(ft.b1).to be(1)
+        expect(ft.b2).to be(0)
       end
 
-      it 'adds muliple-bit attributes on an Int attribute' do
+      it 'defines boolean methods on 1-bit attributes' do
         BSStructSpec::STest.class_eval do
-          define_bit_attrs_on :u8, :f1, 4, :f2, :f3, 3
+          define_bit_attr :u8, b0: 1, b1: 1, b2: 6
+        end
+
+        st = BSStructSpec::STest.new
+        expect(st).to respond_to(:b0?)
+        expect(st).to respond_to(:b1?)
+        expect(st).to_not respond_to(:b2?)
+
+        st.u8 = 0x40
+        expect(st.b0?).to be(false)
+        expect(st.b1?).to be(true)
+      end
+
+      it 'accepts booelab on 1-bit setters' do
+        BSStructSpec::STest.class_eval do
+          define_bit_attr :u8, b0: 1, b1: 1, b2: 6
+        end
+
+        st = BSStructSpec::STest.new
+        st.b0 = true
+        st.b1 = false
+        expect(st.u8).to eq(0x80)
+      end
+
+      it 'adds muliple-bit attributes' do
+        BSStructSpec::STest.class_eval do
+          define_bit_attr :u8, f1: 4, f2: 1, f3: 3
         end
         ft = BSStructSpec::STest.new
         expect(ft).to respond_to(:f1)
         expect(ft).to respond_to(:f1=)
+        expect(ft).to respond_to(:f2)
         expect(ft).to respond_to(:f2?)
         expect(ft).to respond_to(:f2=)
         expect(ft).to respond_to(:f3)
         expect(ft).to respond_to(:f3=)
         ft.u8 = 0xc9
         expect(ft.f1).to eq(0xc)
+        expect(ft.f2).to eq(1)
         expect(ft.f2?).to eq(true)
         expect(ft.f3).to eq(1)
         ft.f1 = 0xf
         ft.f2 = false
         ft.f3 = 7
         expect(ft.u8).to eq(0xf7)
-      end
-
-      it 'raises on unknown attribute' do
-        expect { BSStructSpec::STest.class_eval { define_bit_attrs_on :unk, :bit } }
-          .to raise_error(ArgumentError, /^unknown unk attribute/)
-      end
-
-      it 'raises on non-Int attribute' do
-        BSStructSpec::STest.class_eval { define_attr :f1, BinStruct::String }
-        expect { BSStructSpec::STest.class_eval { define_bit_attrs_on :f1, :bit } }
-          .to raise_error(TypeError, 'f1 is not a BinStruct::Int')
-      end
-    end
-
-    describe '.remove_bit_attrs_on' do
-      before(:each) do
-        BSStructSpec::STest.class_eval { define_attr :u8, Int8 }
-      end
-
-      it 'removes defined bit attributes' do
-        BSStructSpec::STest.class_eval do
-          define_bit_attrs_on :u8, :b0, :b1, :b2, :b3, :b4, :b5, :b6, :b7
-        end
-        ft = BSStructSpec::STest.new
-        expect(ft).to respond_to(:b0?)
-        expect(ft).to respond_to(:b0=)
-        expect(ft).to respond_to(:b7?)
-        expect(ft).to respond_to(:b7=)
-
-        BSStructSpec::STest.class_eval { remove_bit_attrs_on :u8 }
-        expect(ft).to_not respond_to(:b0?)
-        expect(ft).to_not respond_to(:b0=)
-        expect(ft).to_not respond_to(:b7?)
-        expect(ft).to_not respond_to(:b7=)
-      end
-
-      it 'does nothing on an attribute with no bit attribute' do
-        expect { BSStructSpec::STest.class_eval { remove_bit_attrs_on :u8 } }.to_not raise_error
       end
     end
 
@@ -329,15 +325,14 @@ module BinStruct
     describe '#bits_on' do
       before(:each) do
         BSStructSpec::STest.class_eval do
-          define_attr :u81, Int8
+          define_bit_attr :u81, f1: 1, f2: 1, f3: 1, f4: 1, f5: 4
           define_attr :u82, Int8
-          define_bit_attrs_on :u81, :f1, :f2, :f3, :f4, :f5, 4
         end
         @ft = BSStructSpec::STest.new
       end
 
       it 'returns a hash: keys are bit attributes, values are their size' do
-        expect(@ft.bits_on(:u81)).to eq(f1: 1, f2: 1, f3: 1, f4: 1, f5: 4)
+        expect(@ft.bits_on(:u81)).to eq(%I[f1 f2 f3 f4 f5])
       end
 
       it 'return nil on attribute which does not define bits' do
@@ -385,6 +380,7 @@ module BinStruct
       let(:inspect_lines) { BSStructSpec::FInspectTest.new.inspect.lines }
 
       it 'shows Int attributes' do
+        pending
         expect(inspect_lines).to include(/Int8\s+int: 0\s+\(0x00\)/)
         expect(inspect_lines).to include(/Int16\s+int2: 0\s+\(0x0000\)/)
       end


### PR DESCRIPTION
Replace `Struct.define_bit_attr_on` by {Struct.define_bit_attr}, {.define_bit_attr_before} and {.define_bit_attr_after}. The generated attribute type is a subclass of new class BitAttr.

Permit to handle bit attributes almost as others attributes.